### PR TITLE
Smaller disk usage for Windows

### DIFF
--- a/websocietysimulator/tools/cache_interaction_tool.py
+++ b/websocietysimulator/tools/cache_interaction_tool.py
@@ -21,9 +21,9 @@ class CacheInteractionTool:
         self.env_dir = os.path.join(data_dir, "lmdb_cache")
         os.makedirs(self.env_dir, exist_ok=True)
 
-        self.user_env = lmdb.open(os.path.join(self.env_dir, "users"), map_size=5 * 1024 * 1024 * 1024)
-        self.item_env = lmdb.open(os.path.join(self.env_dir, "items"), map_size=5 * 1024 * 1024 * 1024)
-        self.review_env = lmdb.open(os.path.join(self.env_dir, "reviews"), map_size=50 * 1024 * 1024 * 1024)
+        self.user_env = lmdb.open(os.path.join(self.env_dir, "users"), map_size=2 * 1024 * 1024 * 1024)
+        self.item_env = lmdb.open(os.path.join(self.env_dir, "items"), map_size=2 * 1024 * 1024 * 1024)
+        self.review_env = lmdb.open(os.path.join(self.env_dir, "reviews"), map_size=8 * 1024 * 1024 * 1024)
 
         # Initialize the database if empty
         self._initialize_db()


### PR DESCRIPTION
There is no need to allocate 50G for the REVIEWS database. On Windows, the file size directly corresponds to the allocated map size, whereas on Linux, the file size reflects the actual used size. Therefore, this consideration primarily applies to Windows users.

Here are the test results for used size:

USERS DB:
  Entries: 889,698
  Total Size: 5120.00 MB
  Used Size: 1491.59 MB
  Utilization: 29.1%

ITEMS DB:
  Entries: 355,800
  Total Size: 5120.00 MB
  Used Size: 1904.78 MB
  Utilization: 37.2%

REVIEWS DB:
  Entries: 6,398,900
  Total Size: 51200.00 MB
  Used Size: 7419.79 MB
  Utilization: 14.5%

